### PR TITLE
Fix Basis Builder

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: "**/cpm_modules"
           key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -31,7 +31,7 @@ jobs:
          path: 'repo'
       - name: Install format dependencies
         run: |
-          pip install clang-format
+          pip install clang-format==18.1.8
           clang-format --version
           pip install cmake_format==0.6.13 pyyaml
           pip install black==23.3.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,31 @@
 # SPDX-FileCopyrightText: 2022 The dune-iga developers mueller@ibb.uni-stuttgart.de
 # SPDX-License-Identifier: CC0-1.0
 
-build-cmake
+/.devcontainer
+docker-compose.yml
+.clangd
+
+/build*
+/.vscode
+/cpm_modules
+.DS_Store
 .idea/
+cmake-build-debug/
 *cmake-build*
-dune/python/test/setpath.py
-*.vtu
+cmake-build-debug-dockerfull/
+cmake-build-debug-dockerfulldocs/
+cmake-build-release/
+cmake-build-release-dockerfull/
+cmake-build-relwithdebinfo/
+docs/website/drawio-exporter
 *.pyc
-# need to add other file formats
+.cache/
+
+ikarus/python/test/setpath.py
+python/pyikarus.egg-info/
+dist/
+_skbuild/
+MANIFEST.in
+*.vtu
+*.vtr
+dune/python/test/setpath.py

--- a/codespellignore
+++ b/codespellignore
@@ -7,3 +7,4 @@ ibra
 knot
 codim
 localL
+linS

--- a/codespellignore
+++ b/codespellignore
@@ -6,3 +6,4 @@ numer
 ibra
 knot
 codim
+localL

--- a/dune/iga/io/ibra/ibrareader.hh
+++ b/dune/iga/io/ibra/ibrareader.hh
@@ -85,8 +85,8 @@ public:
         }
       }
     } catch (json::parse_error& ex) {
-      DUNE_THROW(Dune::IOError, "Error in reading input stream: "
-                                    << ", parse error at byte " << ex.byte << " What: " << ex.what());
+      DUNE_THROW(Dune::IOError,
+                 "Error in reading input stream: " << ", parse error at byte " << ex.byte << " What: " << ex.what());
     }
 
     // Make Connections

--- a/python/dune/iga/basis/__init__.py
+++ b/python/dune/iga/basis/__init__.py
@@ -21,7 +21,7 @@ duneFunctionsLayouts = {"lexicographic": "Lexicographic", "interleaved": "Interl
 
 def indexMergingStrategy(blocked, layout):
     return (
-        "Dune::Functions::BasisBuilder::"
+        "Dune::Functions::BasisFactory::"
         + ("Blocked" if blocked else "Flat")
         + duneFunctionsLayouts[layout]
     )


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Use 'Dune::Functions::BasisFactory' instead of 'BasisBuilder' in indexMergingStrategy